### PR TITLE
Null fix

### DIFF
--- a/src/main/java/edu/matc/controller/ProcessReports.java
+++ b/src/main/java/edu/matc/controller/ProcessReports.java
@@ -85,6 +85,7 @@ public class ProcessReports {
     // method takes a single zip code and its city/state data,
     //and loads the income data for the year called
     private void setReport(int zip, String state, String city, int year){
+        logger.debug("setReport: ZIP: " + zip+" state: " + state + " year: " + year );
         IncomeDataDAO incomeDataDAO = new IncomeDataDAO();
         ArrayList<IncomeData> incomeData = new ArrayList<IncomeData>();
 
@@ -96,7 +97,10 @@ public class ProcessReports {
             report.setState(state);
             report.setYear(year);
 
-            report.setHouseholdMedianIncome(incomeData.get(0).getEstimateHouseholdsMedianIncomeDollars());
+            // Ignore null results.
+            if (incomeData.size() > 0) {
+                report.setHouseholdMedianIncome(incomeData.get(0).getEstimateHouseholdsMedianIncomeDollars());
+            }
 
             reports.add(report);
             logger.info("SetReport ran = new report object: "+report);

--- a/src/main/java/edu/matc/persistence/IncomeDataDAO.java
+++ b/src/main/java/edu/matc/persistence/IncomeDataDAO.java
@@ -6,7 +6,9 @@ import org.hibernate.*;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,8 +53,10 @@ public class IncomeDataDAO {
      * @return IncomeData
      */
     public List<IncomeData> getIncomeData(int zip, int year) {
+        logger.debug("Get income by zip and year. YEAR: " + year + " ZIP: " + zip);
         List<IncomeData> incomeData = null;
-        final String columnName = "zipCode";
+        final String zipColumn = "zipCode";
+        final String yearColumn = "year";
 
         try (Session session = sessionFactory.openSession();){
 
@@ -63,10 +67,11 @@ public class IncomeDataDAO {
 
             query.select(root).where(
                     builder.and(
-                            builder.equal(root.get(columnName),zip),
-                            builder.equal(root.get("year"),year)
+                            builder.equal(root.get(zipColumn),zip),
+                            builder.equal(root.get(yearColumn),year)
                     ));
             incomeData = session.createQuery(query).getResultList();
+
         } catch (HibernateException he) {
             logger.debug("Hibernate exception thrown in getIncome with zip and year");
             logger.catching(he);
@@ -75,5 +80,48 @@ public class IncomeDataDAO {
         }
         return incomeData;
     }
+
+//    /** This method take a List of zip codes and years and gets all years for all zip codes.
+//     *
+//     * @param zips Zip Codes
+//     * @param years Years
+//     * @return Income data matching all supplied zip codes and years.
+//     */
+//    public List<IncomeData> getIncomeData(List<Integer> zips, List<Integer> years) {
+//
+//        List<IncomeData> incomeData = null;
+//        final String zipColumn = "zipCode";
+//        final String yearColumn = "year";
+//
+//        try (Session session = sessionFactory.openSession();){
+//
+//            CriteriaBuilder builder = session.getCriteriaBuilder();
+//            CriteriaQuery<IncomeData> query = builder.createQuery(IncomeData.class);
+//
+//            Root<IncomeData> root = query.from(IncomeData.class);
+//
+//            List<Predicate> predicates = new ArrayList<>();
+//
+//            builder.disjunction();
+//
+//            for (Integer zip : zips) {
+//                for (Integer year : years) {
+//                    predicates.add(builder.equal(root.get(yearColumn), year));
+//                    predicates.add(builder.equal(root.get(zipColumn), zip));
+//                    builder.disjunction();
+//                }
+//            }
+//            query.select(root).where(predicates.toArray(new Predicate[]{}));
+//            query.orderBy(builder.asc(root.get(yearColumn)),builder.asc(root.get(zipColumn)));
+//            incomeData = session.createQuery(query).getResultList();
+//
+//        } catch (HibernateException he) {
+//            logger.debug("Hibernate exception thrown in getIncome with zip and year");
+//            logger.catching(he);
+//        } catch (Exception ex) {
+//            logger.catching(ex);
+//        }
+//        return incomeData;
+//    }
 
 }

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -9,7 +9,7 @@ appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c
 
 appender.file.type = File
 appender.file.name = LOGFILE
-appender.file.fileName=${filepath}/InvoiceMaker.log
+appender.file.fileName=${filepath}/JavaCollective.log
 appender.file.layout.type=PatternLayout
 appender.file.layout.pattern=[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
 

--- a/src/test/java/edu/matc/persistence/IncomeDataDAOTest.java
+++ b/src/test/java/edu/matc/persistence/IncomeDataDAOTest.java
@@ -62,7 +62,34 @@ class IncomeDataDAOTest {
         incomeData.forEach((record) -> {
                     if(record.getYear() == 2018)
                         assertEquals( (Float)58261f,record.getEstimateHouseholdsMeanIncomeDollars());
+                    logger.debug("Record Data: " + record.getYear() +" "+ record.getZipCode() +" "+ record.getEstimateHouseholdsMeanIncomeDollars());
                 }
         );
     }
+
+//    @Test
+//    void testGetIncomeData() {
+//
+//        ArrayList<Integer> zips = new ArrayList<>();
+//        zips.add(600086);
+//        zips.add(60415);
+//        zips.add(60602);
+//        zips.add(60604);
+//
+//        ArrayList<Integer> years = new ArrayList<>();
+//        years.add(2019);
+//        years.add(2018);
+//        years.add(2017);
+//        years.add(2016);
+//        years.add(2015);
+//
+//        ArrayList<IncomeData> incomeData = new ArrayList<>();
+//        incomeData = (ArrayList<IncomeData>) incomeDataDAO.getIncomeData(zips,years);
+//
+//        incomeData.forEach((dataum) -> {
+//            logger.info("Year: " + dataum.getYear() + " Zip: " + dataum.getZipCode() + " Income: " + dataum.getEstimateHouseholdsMeanIncomeDollars());
+//
+//        });
+//
+//    }
 }


### PR DESCRIPTION
Fixed the null pointer that occurred when there were no matching results for a zipcode. Turns out it was already partially fixed. I changed the code so that it will skip over nulls since we don't have real data to return. I also spent a bunch of time trying to create a query that will take an array of zips and years and get them all at once. The current method is very slow when there are a lot of zip codes. 